### PR TITLE
companyUrl and repositoryName added to project properties

### DIFF
--- a/src/components/ProjectInfo.vue
+++ b/src/components/ProjectInfo.vue
@@ -4,13 +4,22 @@
       <div class="sidebar-row mb-2 mb-xl-5">
         <h3 class="sidebar-title mb-2 mb-xl-4">Project Info</h3>
         <ul class="list-unstyled ps-2">
-          <li v-if="project.companyName" class="mb-2 mb-xl-4">
+          <li
+            v-if="project.companyName || project.companyUrl"
+            class="mb-2 mb-xl-4"
+          >
             <font-awesome-icon
               icon="building"
               class="me-3 text-primary"
               transform="grow-6 down-2"
             />
-            <strong>Company:</strong> {{ project.companyName }}
+            <strong>Company: </strong>
+            <a v-if="project.companyUrl" :href="project.companyUrl">{{
+              project.companyName || project.companyUrl
+            }}</a>
+            <span v-if="project.companyName && !project.companyUrl">
+              {{ project.companyName }}
+            </span>
           </li>
           <li
             v-if="project.url || project.urlName || project.archivedUrl"
@@ -42,14 +51,16 @@
             />
             <strong>Type:</strong> {{ project.type }}
           </li>
-          <li v-if="project.repositoryUrl">
+          <li v-if="project.repositoryUrl" class="mb-2 mb-xl-4">
             <font-awesome-icon
               :icon="['fab', 'github']"
               class="me-3 text-primary"
               transform="grow-6 down-2"
             />
             <strong>Source Code: </strong>
-            <a :href="project.repositoryUrl">{{ project.repositoryUrl }}</a>
+            <a :href="project.repositoryUrl">{{
+              project.repositoryName || project.repositoryUrl
+            }}</a>
           </li>
         </ul>
       </div>

--- a/src/types/IProject.ts
+++ b/src/types/IProject.ts
@@ -73,6 +73,7 @@ export interface IProject {
   archivedUrl?: string;
   type: string;
   companyName?: string;
+  companyUrl?: string;
   thumbnail: string;
   summaryTitle: string;
   summary: string;
@@ -81,6 +82,7 @@ export interface IProject {
   technologies: ITechnology[];
   thumbnailLogo: string;
   featured: boolean;
+  repositoryName?: string;
   repositoryUrl?: string;
 }
 export interface ICompany {


### PR DESCRIPTION
Closes #133 
Closes #134 

Similar to `Site Name`, I added additional properties to projects, so the portfolio author can generate:
- Company name with a custom URL
- Repository URL with name covering its link

## All working company variants:
| #   | project.companyName | project.companyUrl | Rendered "Company" Section                             |
| --- | ------------------- | ------------------ | ------------------------------------------------------ |
| 1   | yes                 | yes                | `<a href="project.companyUrl">project.companyName</a>` |
| 2   | yes                 | no                 | `project.companyName`                                  |
| 3   | no                  | yes                | `<a href="project.companyUrl">project.companyUrl</a>`  |
| 4   | no                  | no                 | `Not Rendered`                                         |

## All working repository variants:
| #   | project.repositoryName | project.repositoryUrl | Rendered "Source Code" Section                               |
| --- | ---------------------- | --------------------- | ------------------------------------------------------------ |
| 1   | yes                    | yes                   | `<a href="project.repositoryUrl">project.repositoryName</a>` |
| 2   | yes                    | no                    | `Not Rendered`                                               |
| 3   | no                     | yes                   | `<a href="project.repositoryUrl">project.repositoryUrl</a>`  |
| 4   | no                     | no                    | `Not Rendered`                                               |