### PR TITLE
Volar plugin is deprecated

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,10 @@
 {
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "Vue.volar",                        // Vue 3 Language Features
-    "Vue.vscode-typescript-vue-plugin", // Typescript Vue Plugin (Volar)
+    "Vue.volar", // Vue 3 Language Features
     "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint",
+    "dbaeumer.vscode-eslint"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-    "octref.vetur",
-	]
+  "unwantedRecommendations": ["octref.vetur"]
 }

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ This template should help get you started developing with Vue 3 in Vite.
 
 ## Recommended IDE Setup
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) (and disable Vetur) + [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-typescript-vue-plugin).
+- [VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) (and disable Vetur).
+- ~~[TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-typescript-vue-plugin) is deprecated.~~
 
 ## Type Support for `.vue` Imports in TS
 
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-typescript-vue-plugin) to make the TypeScript language service aware of `.vue` types.
+TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking.
+
+[Takeover Mode is no longer needed in version 2.0 and has been deprecated.](https://github.com/vuejs/language-tools/releases/tag/v2.0.0)
+
+### Method for the older version
 
 If the standalone TypeScript plugin doesn't feel fast enough to you, Volar has also implemented a [Take Over Mode](https://github.com/johnsoncodehk/volar/discussions/471#discussioncomment-1361669) that is more performant. You can enable it by the following steps:
 


### PR DESCRIPTION
TypeScript Vue Plugin (Volar) is deprecated. Use the **Vue - Official** extension instead.

![obraz](https://github.com/noisy/portfolio/assets/1151664/b39c29c6-5772-4594-b599-43bfe55160ad)
